### PR TITLE
공통 컴포넌트 Button 추가

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,12 @@
 const Home = () => {
-  return <main>메인입니다</main>;
+  return (
+    <main>
+      메인입니다
+      <label>
+        <input></input>
+      </label>
+    </main>
+  );
 };
 
 export default Home;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,5 @@
 const Home = () => {
-  return (
-    <main>
-      메인입니다
-      <label>
-        <input></input>
-      </label>
-    </main>
-  );
+  return <main>메인입니다</main>;
 };
 
 export default Home;

--- a/src/components/Button/index.module.scss
+++ b/src/components/Button/index.module.scss
@@ -10,20 +10,20 @@
     background-color: $blue-40;
     &:disabled {
       color: $gray-50;
-      background-color: #f8f8f8;
+      background-color: $gray-disabled;
     }
     &:hover {
       background-color: $blue-50;
     }
     &:focus {
       color: $blue-40;
-      background-color: #fff;
+      background-color: $white;
       border: 1px solid $blue-40;
     }
   }
   &--color-outline {
     color: $blue-40;
-    background-color: #fff;
+    background-color: $white;
     border: 1px solid $blue-40;
     &:disabled {
       color: $gray-60;
@@ -35,6 +35,13 @@
     &:focus {
       color: $blue-40;
       background-color: $blue-20;
+    }
+    &--gray {
+      color: $gray-70;
+      border: 1px solid $gray-30;
+      &:hover {
+        background-color: $gray-10;
+      }
     }
   }
 

--- a/src/components/Button/index.module.scss
+++ b/src/components/Button/index.module.scss
@@ -1,6 +1,60 @@
-.button--active {
-  font-size: 24px;
-  font-weight: 700;
-  border: 1px solid black;
-  box-sizing: border-box;
+@import "@/styles/style.scss";
+
+.button {
+  @include flex;
+  border-radius: 8px;
+  line-height: 1.4;
+
+  &--color-solid {
+    color: #fff;
+    background-color: $blue-40;
+    &:disabled {
+      color: $gray-50;
+      background-color: #f8f8f8;
+    }
+    &:hover {
+      background-color: $blue-50;
+    }
+    &:focus {
+      color: $blue-40;
+      background-color: #fff;
+      border: 1px solid $blue-40;
+    }
+  }
+  &--color-outline {
+    color: $blue-40;
+    background-color: #fff;
+    border: 1px solid $blue-40;
+    &:disabled {
+      color: $gray-60;
+      border: 1px solid $gray-30;
+    }
+    &:hover {
+      background-color: $gray-10;
+    }
+    &:focus {
+      color: $blue-40;
+      background-color: $blue-20;
+    }
+  }
+
+  &--size-small {
+    padding: 0 42px;
+    height: 40px;
+    @include text-style(16, false, 600);
+  }
+  &--size-medium {
+    padding: 0 137px;
+    height: 50px;
+    @include text-style(18, false, 600);
+  }
+  &--size-large {
+    padding: 0 137px;
+    height: 60px;
+    @include text-style(18, false, 600);
+  }
+
+  &--full {
+    width: 100%;
+  }
 }

--- a/src/components/Button/index.module.scss
+++ b/src/components/Button/index.module.scss
@@ -1,0 +1,6 @@
+.button--active {
+  font-size: 24px;
+  font-weight: 700;
+  border: 1px solid black;
+  box-sizing: border-box;
+}

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,0 +1,11 @@
+import styles from "./index.module.scss";
+
+const Button = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <button type="button" className={styles["button--active"]}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -3,7 +3,7 @@ import ms from "@/utils/modifierSelector";
 import styles from "./index.module.scss";
 
 type ButtonProps = {
-  color?: "solid" | "outline";
+  color?: "solid" | "outline" | "outline--gray";
   size?: "small" | "medium" | "large";
   full?: boolean;
 } & {

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -24,7 +24,7 @@ const Button = ({
   createElement(
     "button",
     {
-      className: cn(`--color-${color}`, `--size-${size}`, full ? "--full" : ""),
+      className: cn(`--color-${color}`, `--size-${size}`, full && "--full"),
       type: type === "submit" ? "submit" : "button",
       disabled,
       ...props,

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,11 +1,35 @@
+import { createElement, ButtonHTMLAttributes } from "react";
+import ms from "@/utils/modifierSelector";
 import styles from "./index.module.scss";
 
-const Button = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <button type="button" className={styles["button--active"]}>
-      {children}
-    </button>
+type ButtonProps = {
+  color?: "solid" | "outline";
+  size?: "small" | "medium" | "large";
+  full?: boolean;
+} & {
+  children: React.ReactNode;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+const cn = ms(styles, "button");
+
+const Button = ({
+  children,
+  color = "solid",
+  size = "small",
+  full = false,
+  type = "button",
+  disabled = false,
+  ...props
+}: ButtonProps) =>
+  createElement(
+    "button",
+    {
+      className: cn(`--color-${color}`, `--size-${size}`, full ? "--full" : ""),
+      type: type === "submit" ? "submit" : "button",
+      disabled,
+      ...props,
+    },
+    children,
   );
-};
 
 export default Button;

--- a/src/styles/constants/_colors.scss
+++ b/src/styles/constants/_colors.scss
@@ -1,3 +1,6 @@
+$white: #fff;
+
+$gray-disabled: #f8f8f8;
 $gray-10: #f5f7fa;
 $gray-20: #ededef;
 $gray-30: #dadada;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -15,6 +15,7 @@ html {
 
 body {
   font-family: $font-main;
+  line-height: 1.2;
 }
 
 h1 {

--- a/src/utils/modifierSelector.ts
+++ b/src/utils/modifierSelector.ts
@@ -1,8 +1,12 @@
 const modifierSelector =
   (style: { readonly [key: string]: string }, initialClass: string) =>
   (...modifiers: (string | boolean)[]) =>
-    [initialClass, ...modifiers.map((modifier) => `${initialClass}${modifier}`)]
-      .filter((selector) => typeof selector === "string" && selector.length)
+    [
+      initialClass,
+      ...modifiers
+        .filter((selector) => typeof selector === "string" && selector.length)
+        .map((modifier) => `${initialClass}${modifier}`),
+    ]
       .map((selector) => style[selector])
       .join(" ");
 

--- a/src/utils/modifierSelector.ts
+++ b/src/utils/modifierSelector.ts
@@ -1,0 +1,8 @@
+const modifierSelector =
+  (style: { readonly [key: string]: string }, initialClass: string) =>
+  (...modifiers: string[]) =>
+    [initialClass, ...modifiers.map((modifier) => `${initialClass}${modifier}`)]
+      .map((selector) => style[selector])
+      .join(" ");
+
+export default modifierSelector;

--- a/src/utils/modifierSelector.ts
+++ b/src/utils/modifierSelector.ts
@@ -1,7 +1,8 @@
 const modifierSelector =
   (style: { readonly [key: string]: string }, initialClass: string) =>
-  (...modifiers: string[]) =>
+  (...modifiers: (string | boolean)[]) =>
     [initialClass, ...modifiers.map((modifier) => `${initialClass}${modifier}`)]
+      .filter((selector) => typeof selector === "string" && selector.length)
       .map((selector) => style[selector])
       .join(" ");
 


### PR DESCRIPTION
## 공통 Button 추가

```typescript
const Button = ({
  children,
  color = "solid",
  size = "small",
  full = false,
  type = "button",
  disabled = false,
  ...props
}: ButtonProps) =>
  createElement(
    "button",
    {
      className: cn(`--color-${color}`, `--size-${size}`, full && "--full"),
      type: type === "submit" ? "submit" : "button",
      disabled,
      ...props,
    },
    children,
  );
```

기본 인자로 color="solid", size="small", full=false, type="button", disabled=false 들어가게 되어 있고 다음과 같이 사용 가능합니다.

```typescript
<Button color="outline" size="small">
  취소
</Button>

<Button color="solid" size="medium" type="submit" full>
  등록하기
</Button>
```

- 사이즈 별 width, height, padding 값은 제가 임의로 맞춘 값이라 나중에 협의 후 수정 가능합니다.

- eslint 오류 때문에 인자로 받은 타입 그대로 못 넘겨주고 "submit"이나 "button" 두 값 중에 하나만 사용 가능합니다. type="reset" 딱히 쓸 일 없을 거 같은데 필요한 경우 나중에 rule 추가 후 수정 해야합니다.

## SCSS Modifier 선택자 관련해서 헬퍼 함수 추가

```typescript
const modifierSelector =
  (style: { readonly [key: string]: string }, initialClass: string) =>
  (...modifiers: (string | boolean)[]) =>
    [
      initialClass,
      ...modifiers
        .filter((selector) => typeof selector === "string" && selector.length)
        .map((modifier) => `${initialClass}${modifier}`),
    ]
      .map((selector) => style[selector])
      .join(" ");
```

위에도 있는 부분인데 다음과 같이 사용 가능합니다.

```typescript
import ms from "@/utils/modifierSelector";

const cn = ms(styles, "button");

...

  return <button className={cn(`--color-${color}`, `--size-${size}`, full && "--full")}>버튼</button>;

...
```

## 기타 전역 CSS 수정