### PR TITLE
공통 컴포넌트 Selectbox 추가

### DIFF
--- a/src/assets/icons/icon-direction-down-20.svg
+++ b/src/assets/icons/icon-direction-down-20.svg
@@ -1,0 +1,5 @@
+<svg width="current" height="current" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="icon/direction">
+<path id="Vector" d="M16.25 7.5L10 13.75L3.75 7.5" stroke="#4B4D5A" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/assets/icons/icon-direction-up-20.svg
+++ b/src/assets/icons/icon-direction-up-20.svg
@@ -1,0 +1,5 @@
+<svg width="current" height="current" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="icon/direction">
+<path id="Vector" d="M3.75 12.5L10 6.25L16.25 12.5" stroke="#4B4D5A" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/components/Input/index.module.scss
+++ b/src/components/Input/index.module.scss
@@ -5,7 +5,7 @@
   padding: 0 17px;
   border: 2px solid $gray-20;
   border-radius: 8px;
-  line-height: 50px;
+  line-height: 1.4;
   background-color: $white;
 
   &::placeholder {

--- a/src/components/Input/index.module.scss
+++ b/src/components/Input/index.module.scss
@@ -1,47 +1,3 @@
-.input-field {
-  @include column-flex(center, start);
-  max-width: 337px;
-  width: 100%;
-  margin-bottom: 12px;
-  line-height: 1.4;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-
-  &--full {
-    max-width: 100%;
-  }
-
-  &--error {
-    .input {
-      border: 1px solid $alert-red;
-
-      &:focus {
-        border-color: $alert-red;
-      }
-    }
-  }
-}
-
-.label {
-  @include text-style(14, $gray-80);
-  margin-bottom: 2px;
-}
-
-.input-wrap {
-  position: relative;
-  width: 100%;
-
-  .btn-toggle-pw {
-    @include pos-center-y;
-    right: 15px;
-    z-index: 1;
-    width: 20px;
-    height: 20px;
-  }
-}
-
 .input {
   @include text-style(14, $black);
   width: 100%;
@@ -64,6 +20,45 @@
   &:read-only {
     @include text-style(14, $gray-50);
     background-color: $gray-disabled;
+  }
+
+  &-field {
+    @include column-flex(center, start);
+    max-width: 337px;
+    width: 100%;
+    margin-bottom: 12px;
+    line-height: 1.4;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    &--full {
+      max-width: 100%;
+    }
+
+    &--error {
+      .input {
+        border: 1px solid $alert-red;
+
+        &:focus {
+          border-color: $alert-red;
+        }
+      }
+    }
+  }
+
+  &-wrapper {
+    position: relative;
+    width: 100%;
+
+    .btn-toggle-pw {
+      @include pos-center-y;
+      right: 15px;
+      z-index: 1;
+      width: 20px;
+      height: 20px;
+    }
   }
 }
 

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,11 +1,10 @@
-"use client";
-
 import ms from "@/utils/modifierSelector";
 import { InputHTMLAttributes, createElement, useState } from "react";
 import { UseFormRegisterReturn } from "react-hook-form";
 import IconPasswordHidden from "@/assets/icons/icon-password-hidden.svg";
 import IconPasswordVisible from "@/assets/icons/icon-password-visible.svg";
 import styles from "./index.module.scss";
+import Label from "../Label";
 
 type InputProps = {
   id: string;
@@ -28,7 +27,7 @@ const Input = ({
 }: InputProps) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
-  const togglePasswordVisibility = () => {
+  const handleTogglePasswordIcon = () => {
     setIsPasswordVisible(!isPasswordVisible);
   };
 
@@ -36,12 +35,8 @@ const Input = ({
 
   return (
     <div className={cn("", error ? "--error" : "", full && "--full")}>
-      {label && (
-        <label className={styles.label} htmlFor={id}>
-          {label}
-        </label>
-      )}
-      <div className={styles["input-wrap"]}>
+      {label && <Label htmlFor={id}>{label}</Label>}
+      <div className={styles["input-wrapper"]}>
         {createElement("input", {
           className: styles.input,
           id,
@@ -53,7 +48,7 @@ const Input = ({
           <button
             type="button"
             className={styles["btn-toggle-pw"]}
-            onClick={togglePasswordVisibility}
+            onClick={handleTogglePasswordIcon}
           >
             {isPasswordVisible ? (
               <IconPasswordHidden />

--- a/src/components/Label/index.module.scss
+++ b/src/components/Label/index.module.scss
@@ -1,0 +1,5 @@
+.label {
+  @include text-style(14, $gray-80);
+  margin-bottom: 6px;
+  line-height: 1.4;
+}

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,0 +1,16 @@
+import styles from "./index.module.scss";
+
+type LabelProps = {
+  htmlFor: string;
+  children: React.ReactNode;
+};
+
+const Label = ({ htmlFor, children }: LabelProps) => {
+  return (
+    <label className={styles.label} htmlFor={htmlFor}>
+      {children}
+    </label>
+  );
+};
+
+export default Label;

--- a/src/components/Selectbox/index.module.scss
+++ b/src/components/Selectbox/index.module.scss
@@ -1,0 +1,61 @@
+.select {
+  @include text-style(14, $black);
+  position: relative;
+  width: 100%;
+  padding: 13px 17px;
+  border: 2px solid $gray-20;
+  border-radius: 8px;
+  line-height: 1.4;
+  background-color: $white;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+
+  &-wrapper {
+    @include column-flex(center, start);
+    position: relative;
+    max-width: 337px;
+    width: 100%;
+    margin-bottom: 12px;
+    line-height: 1.4;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    &--full {
+      max-width: 100%;
+    }
+
+    .option {
+      position: absolute;
+      left: 0;
+      top: calc(100% + 10px);
+      width: 100%;
+      padding: 16px;
+      border-radius: 8px;
+      box-shadow: $box-shadow;
+
+      &__item {
+        @include text-style(14);
+        margin-bottom: 9px;
+        cursor: pointer;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+
+        &:hover {
+          color: $blue-40;
+        }
+      }
+    }
+  }
+
+  svg {
+    @include pos-center-y;
+    right: 17px;
+  }
+}

--- a/src/components/Selectbox/index.module.scss
+++ b/src/components/Selectbox/index.module.scss
@@ -33,9 +33,11 @@
       position: absolute;
       left: 0;
       top: calc(100% + 10px);
+      z-index: 1;
       width: 100%;
       padding: 16px;
       border-radius: 8px;
+      background-color: $white;
       box-shadow: $box-shadow;
 
       &__item {

--- a/src/components/Selectbox/index.module.scss
+++ b/src/components/Selectbox/index.module.scss
@@ -1,63 +1,130 @@
-.select {
-  @include text-style(14, $black);
-  position: relative;
+.select-wrapper {
+  @include column-flex(center, start);
   width: 100%;
-  padding: 13px 17px;
-  border: 2px solid $gray-20;
-  border-radius: 8px;
+  position: relative;
+  margin-bottom: 12px;
   line-height: 1.4;
-  background-color: $white;
-  cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
 
-  &-wrapper {
-    @include column-flex(center, start);
-    position: relative;
-    max-width: 337px;
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  .option {
+    position: absolute;
+    left: 0;
+    top: calc(100% + 12px);
+    z-index: 1;
+    overflow: hidden;
     width: 100%;
-    margin-bottom: 12px;
-    line-height: 1.4;
+    border-radius: 8px;
+    background-color: $white;
+    box-shadow: $box-shadow;
 
-    &:last-child {
-      margin-bottom: 0;
-    }
+    &__item {
+      @include text-style(14, $gray-80);
+      height: 50px;
+      padding: 13px 14px;
+      line-height: 24px;
+      cursor: pointer;
 
-    &--full {
-      max-width: 100%;
-    }
+      &:last-child {
+        margin-bottom: 0;
+      }
 
-    .option {
-      position: absolute;
-      left: 0;
-      top: calc(100% + 10px);
-      z-index: 1;
-      width: 100%;
-      padding: 16px;
-      border-radius: 8px;
-      background-color: $white;
-      box-shadow: $box-shadow;
+      &:hover {
+        @include text-style(14, $blue-40, 500);
+        background-color: $sky-blue;
+      }
 
-      &__item {
-        @include text-style(14);
-        margin-bottom: 9px;
-        cursor: pointer;
-
-        &:last-child {
-          margin-bottom: 0;
-        }
-
-        &:hover {
-          color: $blue-40;
-        }
+      span {
+        display: block;
       }
     }
   }
 
-  svg {
-    @include pos-center-y;
-    right: 17px;
+  .select {
+    @include text-style(14, $gray-80);
+    position: relative;
+    width: 100%;
+    height: 50px;
+    padding: 13px 17px;
+    border: 2px solid $gray-20;
+    border-radius: 8px;
+    line-height: 1.4;
+    background-color: $white;
+    cursor: pointer;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+
+    svg {
+      @include pos-center-y;
+      right: 16px;
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  &--size-small {
+    max-width: 90px;
+
+    .select {
+      @include text-style(14, $black);
+      height: 36px;
+      padding: 8px 10px;
+      border-width: 1px;
+      border-radius: 4px;
+      line-height: 18px;
+
+      svg {
+        right: 10px;
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    .option {
+      border: 1px solid $gray-20;
+      text-align: center;
+
+      &__item {
+        height: 40px;
+        padding: 10px;
+        line-height: 20px;
+        color: $black;
+      }
+    }
+  }
+
+  &--size-medium {
+    max-width: 114px;
+
+    .select {
+      @include text-style(16, $black);
+      height: 38px;
+      padding: 8px 16px;
+      border-width: 1px;
+      border-radius: 4px;
+      line-height: 18px;
+
+      svg {
+        right: 13px;
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    .option {
+      border: 1px solid $gray-20;
+      text-align: center;
+
+      &__item {
+        height: 40px;
+        padding: 10px;
+        line-height: 20px;
+        color: $black;
+      }
+    }
   }
 }

--- a/src/components/Selectbox/index.tsx
+++ b/src/components/Selectbox/index.tsx
@@ -35,6 +35,8 @@ const Selectbox = ({
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       setShowOptions((prev) => !prev);
+    } else if (e.key === "Escape") {
+      setShowOptions(false);
     }
   };
 
@@ -58,13 +60,13 @@ const Selectbox = ({
         role="button"
         tabIndex={0}
         className={styles.select}
-        aria-expanded={showOptions}
+        aria-expanded={showOptions ? "true" : "false"}
       >
         <span>{selected ? selected.optionLabel : placeholder}</span>
         {showOptions ? (
-          <IconDirectionUp width="100%" height="100%" />
+          <IconDirectionUp width="20px" height="20px" />
         ) : (
-          <IconDirectionDown width="100%" height="100%" />
+          <IconDirectionDown width="20px" height="20px" />
         )}
       </div>
       {showOptions && (

--- a/src/components/Selectbox/index.tsx
+++ b/src/components/Selectbox/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
-import IconDirectionDown from "@/assets/icons/icon-direction-down-gray.svg";
-import IconDirectionUp from "@/assets/icons/icon-direction-up-gray.svg";
+import ms from "@/utils/modifierSelector";
+import IconDirectionDown from "@/assets/icons/icon-direction-down-20.svg";
+import IconDirectionUp from "@/assets/icons/icon-direction-up-20.svg";
 import styles from "./index.module.scss";
 import Label from "../Label";
 
@@ -12,14 +13,18 @@ export type Option = {
 interface SelectProps {
   label?: string;
   placeholder?: string;
+  size?: "default" | "small" | "medium";
   options: Option[];
   selected: Option | null;
   onChange: (selection: Option) => void;
 }
 
+const cn = ms(styles, "select-wrapper");
+
 const Selectbox = ({
   label,
   placeholder,
+  size = "default",
   selected,
   options,
   onChange,
@@ -44,7 +49,7 @@ const Selectbox = ({
   };
 
   return (
-    <div className={styles["select-wrapper"]}>
+    <div className={cn(`--size-${size}`)}>
       {label && <Label htmlFor="selectbox">{label}</Label>}
       <div
         id="selectbox"
@@ -56,7 +61,11 @@ const Selectbox = ({
         aria-expanded={showOptions}
       >
         <span>{selected ? selected.optionLabel : placeholder}</span>
-        {showOptions ? <IconDirectionUp /> : <IconDirectionDown />}
+        {showOptions ? (
+          <IconDirectionUp width="100%" height="100%" />
+        ) : (
+          <IconDirectionDown width="100%" height="100%" />
+        )}
       </div>
       {showOptions && (
         <ul className={styles.option}>

--- a/src/components/Selectbox/index.tsx
+++ b/src/components/Selectbox/index.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+import IconDirectionDown from "@/assets/icons/icon-direction-down-gray.svg";
+import IconDirectionUp from "@/assets/icons/icon-direction-up-gray.svg";
+import styles from "./index.module.scss";
+import Label from "../Label";
+
+export type Option = {
+  optionLabel: string;
+  value: string | number;
+};
+
+interface SelectProps {
+  label?: string;
+  placeholder?: string;
+  options: Option[];
+  selected: Option | null;
+  onChange: (selection: Option) => void;
+}
+
+const Selectbox = ({
+  label,
+  placeholder,
+  selected,
+  options,
+  onChange,
+}: SelectProps) => {
+  const [showOptions, setShowOptions] = useState(false);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setShowOptions((prev) => !prev);
+    }
+  };
+
+  const handleOptionKeyDown = (
+    e: React.KeyboardEvent<HTMLLIElement>,
+    option: Option,
+  ) => {
+    if (e.key === "Enter") {
+      onChange(option);
+      setShowOptions(false);
+    }
+  };
+
+  return (
+    <div className={styles["select-wrapper"]}>
+      {label && <Label htmlFor="selectbox">{label}</Label>}
+      <div
+        id="selectbox"
+        onClick={() => setShowOptions(!showOptions)}
+        onKeyDown={handleKeyDown}
+        role="button"
+        tabIndex={0}
+        className={styles.select}
+        aria-expanded={showOptions}
+      >
+        <span>{selected ? selected.optionLabel : placeholder}</span>
+        {showOptions ? <IconDirectionUp /> : <IconDirectionDown />}
+      </div>
+      {showOptions && (
+        <ul className={styles.option}>
+          {options.map((option) => (
+            <li
+              onClick={() => {
+                onChange(option);
+                setShowOptions(false);
+              }}
+              onKeyDown={(e) => handleOptionKeyDown(e, option)}
+              key={option.value}
+              className={styles.option__item}
+              tabIndex={0}
+              role="option"
+              aria-selected={selected?.value === option.value}
+            >
+              <span>{option.optionLabel}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default Selectbox;

--- a/src/styles/constants/_breakpoints.scss
+++ b/src/styles/constants/_breakpoints.scss
@@ -1,3 +1,3 @@
-$breakpoint-mobile: 390px;
-$breakpoint-tablet: 758px;
-$breakpoint-desktop: 1024px;
+$breakpoint-mobile: 389px;
+$breakpoint-tablet: 767px;
+$breakpoint-desktop: 1023px;

--- a/src/styles/constants/_colors.scss
+++ b/src/styles/constants/_colors.scss
@@ -20,6 +20,7 @@ $blue-30: #acb8fb;
 $blue-40: #4b65f7;
 $blue-50: #445ce1;
 
+$sky-blue: #f6faff;
 $sky-blue-10: #eaf7ff;
 $sky-blue-100: #18a0fb;
 

--- a/src/styles/constants/_colors.scss
+++ b/src/styles/constants/_colors.scss
@@ -35,3 +35,5 @@ $alert-blue: #0167ff;
 
 $gradation-dain: linear-gradient(to bottom right, #4b65f7, #4bd0ff);
 $gradation-premium: linear-gradient(to bottom right, #6423ff, #c479ff);
+
+$box-shadow: 0 4px 12px 0 rgba(109, 106, 144, 0.2);


### PR DESCRIPTION
# 공통 Selectbox 추가

### 사용 예시
- placeholder는 선택된 option 항목이 없을 때 보여주는 기본 텍스트입니다.
- 기본 디자인은 size="default"이고 small, medium 중 선택하시면 됩니다. (결과화면 이미지 참고)
- selected, options, onChange는 필수 속성입니다.
  - selected: 현재 선택된 항목
  - options: 사용자가 선택할 수 있는 옵션 목록
  - onChange: 사용자가 옵션을 선택했을 때 호출되는 함수 (상태 업데이트)

```typescript
const [selectedItem1, setSelectedItem1] = useState<Option | null>(null);
const [selectedItem2, setSelectedItem2] = useState<Option | null>(null);
const [selectedItem3, setSelectedItem3] = useState<Option | null>(null);

return (
  <div>
    <Selectbox
      label="유형"
      placeholder="선택"
      selected={selectedItem1}
      options={[
        { optionLabel: "포털검색", value: "search" },
        { optionLabel: "지인소개", value: "introduce" },
      ]}
      onChange={setSelectedItem1}
    />

    <Selectbox
      placeholder="카테고리"
      size="small"
      selected={selectedItem2}
      options={[
        { optionLabel: "전체", value: "all" },
        { optionLabel: "맛집", value: "food" },
        { optionLabel: "뷰티", value: "beauty" },
      ]}
      onChange={setSelectedItem2}
    />

    <Selectbox
      placeholder="카테고리2"
      size="medium"
      selected={selectedItem3}
      options={[
        { optionLabel: "전체2", value: "all2" },
        { optionLabel: "맛집2", value: "food2" },
        { optionLabel: "뷰티2", value: "beauty2" },
      ]}
      onChange={setSelectedItem3}
    />
  </div>
);

```
### 예시 결과 화면
![example](https://github.com/user-attachments/assets/65008f30-f113-4e6a-a1d3-1933dea5b858)

<br/>

<br/>
<br/>

# Label 컴포넌트 생성
