### PR TITLE
공통 Checkbox 컴포넌트 radio 타입 추가

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,12 +5,31 @@ const nextConfig = {
     includePaths: [path.join(__dirname, "src", "styles")],
     prependData: "@import '@/styles/style.scss';",
   },
-  webpack: (config) => {
-    config.module.rules.push({
-      test: /\.svg$/i,
-      issuer: /\.[jt]sx?$/,
-      use: ["@svgr/webpack"],
-    });
+  webpack(config) {
+    // Grab the existing rule that handles SVG imports
+    const fileLoaderRule = config.module.rules.find((rule) =>
+      rule.test?.test?.(".svg"),
+    );
+
+    config.module.rules.push(
+      // Reapply the existing rule, but only for svg imports ending in ?url
+      {
+        ...fileLoaderRule,
+        test: /\.svg$/i,
+        resourceQuery: /url/, // *.svg?url
+      },
+      // Convert all other *.svg imports to React components
+      {
+        test: /\.svg$/i,
+        issuer: fileLoaderRule.issuer,
+        resourceQuery: { not: [...fileLoaderRule.resourceQuery.not, /url/] }, // exclude if *.svg?url
+        use: ["@svgr/webpack"],
+      },
+    );
+
+    // Modify the file loader rule to ignore *.svg, since we have it handled now.
+    fileLoaderRule.exclude = /\.svg$/i;
+
     return config;
   },
 };

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -1,0 +1,10 @@
+declare module "*.svg?url" {
+  /**
+   * Use `any` to avoid conflicts with
+   * `@svgr/webpack` plugin or
+   * `babel-plugin-inline-react-svg` plugin.
+   */
+  const content: any;
+
+  export default content;
+}

--- a/src/components/Checkbox/index.module.scss
+++ b/src/components/Checkbox/index.module.scss
@@ -1,26 +1,41 @@
 .checkbox {
   @include inline-flex;
   &__input {
-    display: none;
+    appearance: none;
+    vertical-align: middle;
   }
   &__label {
     position: relative;
     @include inline-flex;
-    width: 16px;
-    height: 16px;
     border: 2px solid $gray-50;
-    border-radius: 2px;
     box-sizing: border-box;
-    & > img {
+    cursor: pointer;
+    &--type-checkbox {
+      border-radius: 2px;
+    }
+    &--type-radio {
+      border-radius: 50%;
+    }
+    & > svg {
       display: none;
     }
   }
   &__input:checked + &__label {
-    & > img {
+    &--type-radio {
+      border-color: $blue-50;
+    }
+    & > svg {
       @include pos-center;
       display: block;
-      width: 24px;
-      height: 24px;
     }
+    & > div {
+      border: 1px solid $blue-50;
+      border-radius: 50%;
+      background-color: $blue-50;
+      box-sizing: border-box;
+    }
+  }
+  &__input:focus + &__label {
+    border-color: $blue-50;
   }
 }

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,35 +1,62 @@
+"use client";
+
 import { InputHTMLAttributes, createElement } from "react";
 import { UseFormRegisterReturn } from "react-hook-form";
-import Image from "next/image";
 import ms from "@/utils/modifierSelector";
-import iconCheckboxCheckedSrc from "@/assets/icons/icon-checkbox-checked.svg";
+import IconCheckboxChecked from "@/assets/icons/icon-checkbox-checked.svg";
 import styles from "./index.module.scss";
 
 type CheckboxProps = {
   id: string;
+  type: "checkbox" | "radio";
   register?: UseFormRegisterReturn<string>;
   children?: React.ReactNode;
-  gap?: string;
+  width?: number;
+  gap?: number;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-const cn = ms(styles, "checkbox");
+const label = ms(styles, "checkbox__label");
 
-const Checkbox = ({ id, register, children, gap, ...props }: CheckboxProps) => {
+const Checkbox = ({
+  id,
+  type,
+  register,
+  children,
+  width = 16,
+  gap,
+  ...props
+}: CheckboxProps) => {
+  const gapInPx = gap && `${gap}px`;
+  const widthInPx = `${width}px`;
+  const checkboxWidth = (width * 3) / 2;
+
   return (
     <label
-      className={cn()}
+      className={styles.checkbox}
       htmlFor={register ? register.name : ""}
-      style={{ gap }}
+      style={{ gap: gapInPx }}
     >
       {createElement("input", {
-        type: "checkbox",
-        className: cn("__input"),
+        type,
+        className: styles.checkbox__input,
         id,
         ...register,
         ...props,
       })}
-      <label className={cn("__label")} htmlFor={id}>
-        <Image src={iconCheckboxCheckedSrc} alt="Icon Check" />
+      <label
+        className={label(`--type-${type}`)}
+        style={{ width: widthInPx, height: widthInPx }}
+        htmlFor={id}
+      >
+        {type === "checkbox" && (
+          <IconCheckboxChecked
+            style={{ width: checkboxWidth, height: checkboxWidth }}
+            viewBox="0 0 24 24"
+          />
+        )}
+        {type === "radio" && (
+          <div style={{ width: (width * 5) / 12, height: (width * 5) / 12 }} />
+        )}
       </label>
       {children}
     </label>


### PR DESCRIPTION
## radio 타입 추가

이제 `type="checkbox"` 또는 `type="radio"`처럼 타입을 명시해 주셔야 사용 가능합니다.

## 인풋 박스 크기 조절 가능

`width` 속성을 주면 픽셀 단위로 인풋 박스 크기를 지정할 수 있습니다.

```typescript
<Checkbox type="checkbox" id="test" width={36}>체크박스</Checkbox>
```

`gap` 속성도 통일해서 string 타입에서 number 타입으로 변경하였습니다. 똑같이 픽셀 단위로 적용됩니다.

## Next SGVR 관련 설정

이제 svg 파일을 임포트 할 때 `?url`을 경로 마지막에 붙이면 일반 이미지 파일처럼 임포트 할 수 있습니다.

참조: [https://react-svgr.com/docs/next/](https://react-svgr.com/docs/next/)