### PR TITLE
feat: 기본 Divide 생성

### DIFF
--- a/src/components/Line/index.module.scss
+++ b/src/components/Line/index.module.scss
@@ -1,0 +1,15 @@
+.line {
+  width: 100%;
+
+  &--type-thin {
+    height: 1px;
+    background-color: $gray-20;
+  }
+
+  &--type-thick {
+    height: 8px;
+    border-top: 1px solid $gray-20;
+    border-bottom: 1px solid $gray-20;
+    background-color: $gray-10;
+  }
+}

--- a/src/components/Line/index.tsx
+++ b/src/components/Line/index.tsx
@@ -1,0 +1,17 @@
+import { createElement } from "react";
+import ms from "@/utils/modifierSelector";
+import styles from "./index.module.scss";
+
+type LineProps = {
+  type?: "thick" | "thin";
+};
+
+const cn = ms(styles, "line");
+
+const Line = ({ type = "thin" }: LineProps) => {
+  return createElement("div", {
+    className: cn(`--type-${type}`),
+  });
+};
+
+export default Line;


### PR DESCRIPTION
모바일에서 사용되는 구분선입니다. 

<Line /> Import 해와서 사용하면 되고  속성 type은 thick 과 thin 을 가질 수 있습니다. 각각 선의 굵기를 나타냅니다.
기본 속성은 thin입니다. 

사용시 아래 처럼 나타납니다.

![divider](https://github.com/user-attachments/assets/142a584b-5cf2-4da8-8a63-270e55401d47)
