### PR TITLE
fix: useSearchParams Suspense로 감싸서 에러 해결

### DIFF
--- a/src/app/board/community/page.tsx
+++ b/src/app/board/community/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import SideNav from "@/components/Board/SideNav";
 import Title from "@/components/Board/Title";
 import CategoryTab from "@/components/CategoryTab";
@@ -42,7 +43,9 @@ const Community = () => {
             </li>
           ))}
         </ul>
-        <Pagination chunkSize={10} totalPages={20} />
+        <Suspense>
+          <Pagination chunkSize={10} totalPages={20} />
+        </Suspense>
       </section>
     </main>
   );


### PR DESCRIPTION
빌드 에러 해결하기 위한 풀리퀘입니다.
<img width="1157" alt="Screenshot 2024-08-24 at 2 04 15 PM" src="https://github.com/user-attachments/assets/b1cecb85-8c3d-49a9-bd75-30010627731a">
참조: [https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout)