### PR TITLE
게시판 상세 페이지 제목 추가

### DIFF
--- a/src/@types/board.ts
+++ b/src/@types/board.ts
@@ -1,8 +1,12 @@
+import { z } from "zod";
+
 export type BoardId = "A" | "B" | "C";
 
 export const BOARD_TYPE = ["announcement", "community", "follows"] as const;
 
 export type BoardType = (typeof BOARD_TYPE)[number];
+
+export const BoardSchema = z.enum(BOARD_TYPE);
 
 export type BoardName = "공지사항" | "커뮤니티" | "맞팔/서이추";
 

--- a/src/app/(board)/[boardType]/[id]/page.tsx
+++ b/src/app/(board)/[boardType]/[id]/page.tsx
@@ -1,0 +1,3 @@
+const BoardPage = () => {};
+
+export default BoardPage;

--- a/src/app/(board)/[boardType]/[id]/page.tsx
+++ b/src/app/(board)/[boardType]/[id]/page.tsx
@@ -1,3 +1,0 @@
-const BoardPage = () => {};
-
-export default BoardPage;

--- a/src/app/(board)/[boardType]/[postId]/page.tsx
+++ b/src/app/(board)/[boardType]/[postId]/page.tsx
@@ -1,0 +1,3 @@
+const Post = () => {};
+
+export default Post;

--- a/src/app/(board)/[boardType]/[postId]/page.tsx
+++ b/src/app/(board)/[boardType]/[postId]/page.tsx
@@ -2,6 +2,7 @@ import { BoardType } from "@/@types/board";
 import { CommunityItemProps } from "@/components/Board/ListItem";
 import Title from "@/components/Board/Title";
 import Line from "@/components/Line";
+import AnnouncementTitle from "@/components/Board/AnnouncementTitle";
 import PostTitle from "@/components/Board/PostTitle";
 
 const Post = async ({
@@ -23,7 +24,11 @@ const Post = async ({
     <>
       <Title boardType={params.boardType} />
       <Line />
-      <PostTitle post={post} />
+      {params.boardType === "announcement" ? (
+        <AnnouncementTitle post={post} />
+      ) : (
+        <PostTitle post={post} />
+      )}
     </>
   );
 };

--- a/src/app/(board)/[boardType]/[postId]/page.tsx
+++ b/src/app/(board)/[boardType]/[postId]/page.tsx
@@ -1,3 +1,31 @@
-const Post = () => {};
+import { BoardType } from "@/@types/board";
+import { CommunityItemProps } from "@/components/Board/ListItem";
+import Title from "@/components/Board/Title";
+import Line from "@/components/Line";
+import PostTitle from "@/components/Board/PostTitle";
+
+const Post = async ({
+  params,
+}: {
+  params: { boardType: BoardType; postId: string };
+}) => {
+  const response = await fetch(
+    `http://127.0.0.1:3000/api/board/${params.boardType}`,
+  );
+  const data: CommunityItemProps[] = await response.json();
+  const post = data.find((item) => item.id === Number(params.postId));
+
+  if (!post) {
+    return null;
+  }
+
+  return (
+    <>
+      <Title boardType={params.boardType} />
+      <Line />
+      <PostTitle post={post} />
+    </>
+  );
+};
 
 export default Post;

--- a/src/app/(board)/[boardType]/layout.module.scss
+++ b/src/app/(board)/[boardType]/layout.module.scss
@@ -14,4 +14,7 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  @include mobile {
+    width: fit-content;
+  }
 }

--- a/src/app/(board)/[boardType]/layout.module.scss
+++ b/src/app/(board)/[boardType]/layout.module.scss
@@ -8,3 +8,10 @@
     gap: 16px;
   }
 }
+
+.page {
+  width: 926px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}

--- a/src/app/(board)/[boardType]/layout.module.scss
+++ b/src/app/(board)/[boardType]/layout.module.scss
@@ -15,6 +15,6 @@
   flex-direction: column;
   gap: 20px;
   @include mobile {
-    width: fit-content;
+    width: 100%;
   }
 }

--- a/src/app/(board)/[boardType]/layout.tsx
+++ b/src/app/(board)/[boardType]/layout.tsx
@@ -1,5 +1,6 @@
+import { notFound } from "next/navigation";
 import SideNav from "@/components/Board/SideNav";
-import { BoardType } from "@/@types/board";
+import { BoardType, BoardSchema } from "@/@types/board";
 import styles from "./layout.module.scss";
 
 const BoardLayout = ({
@@ -9,10 +10,14 @@ const BoardLayout = ({
   params: { boardType: BoardType };
   children: React.ReactNode;
 }) => {
+  if (!BoardSchema.safeParse(params.boardType).success) {
+    notFound();
+  }
+
   return (
     <section className={styles.layout}>
       <SideNav boardType={params.boardType} />
-      {children}
+      <article className={styles.page}>{children}</article>
     </section>
   );
 };

--- a/src/app/(board)/[boardType]/page.module.scss
+++ b/src/app/(board)/[boardType]/page.module.scss
@@ -1,13 +1,3 @@
-.page {
-  width: 926px;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  @include mobile {
-    width: 100%;
-  }
-}
-
 .control {
   display: flex;
   justify-content: space-between;

--- a/src/app/(board)/[boardType]/page.tsx
+++ b/src/app/(board)/[boardType]/page.tsx
@@ -1,20 +1,16 @@
-import { notFound } from "next/navigation";
-import { z } from "zod";
 import Title from "@/components/Board/Title";
 import Search from "@/components/Board/Search";
 import CategoryTab from "@/components/CategoryTab";
 import PostButton from "@/components/Board/PostButton";
 import Line from "@/components/Line";
-import ListItem, { CommunityItemProps } from "@/components/Board/ListItem";
-import AnnouncementItem from "@/components/Board/AnnouncementItem";
+import { CommunityItemProps } from "@/components/Board/ListItem";
+import List from "@/components/Board/List";
 import Pagination from "@/components/Pagination";
-import { BoardType, BOARD_TYPE, CATEGORY_LIST } from "@/@types/board";
+import { BoardType, CATEGORY_LIST } from "@/@types/board";
 import styles from "./page.module.scss";
 
 // 추후 API 연결 후 변경 예정
 export const dynamic = "force-dynamic";
-
-const BoardSchema = z.enum(BOARD_TYPE);
 
 const Board = async ({
   params,
@@ -23,17 +19,13 @@ const Board = async ({
   params: { boardType: BoardType };
   searchParams: Record<string, string>;
 }) => {
-  if (!BoardSchema.safeParse(params.boardType).success) {
-    notFound();
-  }
-
   const response = await fetch(
     `http://localhost:3000/api/board/${params.boardType}`,
   );
   const data: CommunityItemProps[] = await response.json();
 
   return (
-    <article className={styles.page}>
+    <>
       <Title boardType={params.boardType} />
       <section className={styles.control}>
         <nav className={styles.search}>
@@ -48,29 +40,20 @@ const Board = async ({
         <PostButton />
       </section>
       <Line />
-      <ul>
-        {data
-          .slice(
-            10 * (Number(searchParams.page || 1) - 1),
-            10 * Number(searchParams.page || 1),
-          )
-          .map((boardItem) =>
-            params.boardType === "announcement" ? (
-              // eslint-disable-next-line
-              <AnnouncementItem key={boardItem.id} {...boardItem} />
-            ) : (
-              // eslint-disable-next-line
-              <ListItem key={boardItem.id} {...boardItem} />
-            ),
-          )}
-      </ul>
+      <List
+        items={data.slice(
+          10 * (Number(searchParams.page || 1) - 1),
+          10 * Number(searchParams.page || 1),
+        )}
+        boardType={params.boardType}
+      />
       <Pagination
         pathname={`/${params.boardType}`}
         searchParams={searchParams}
         chunkSize={10}
         totalPages={Math.ceil(data.length / 10)}
       />
-    </article>
+    </>
   );
 };
 

--- a/src/app/(board)/[boardType]/page.tsx
+++ b/src/app/(board)/[boardType]/page.tsx
@@ -9,9 +9,6 @@ import Pagination from "@/components/Pagination";
 import { BoardType, CATEGORY_LIST } from "@/@types/board";
 import styles from "./page.module.scss";
 
-// 추후 API 연결 후 변경 예정
-export const dynamic = "force-dynamic";
-
 const Board = async ({
   params,
   searchParams,
@@ -20,7 +17,7 @@ const Board = async ({
   searchParams: Record<string, string>;
 }) => {
   const response = await fetch(
-    `http://localhost:3000/api/board/${params.boardType}`,
+    `http://127.0.0.1:3000/api/board/${params.boardType}`,
   );
   const data: CommunityItemProps[] = await response.json();
 

--- a/src/components/Board/AnnouncementTitle/index.module.scss
+++ b/src/components/Board/AnnouncementTitle/index.module.scss
@@ -1,0 +1,24 @@
+.title {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  &__text {
+    @include text-style(20, false, 600);
+    @include mobile {
+      line-height: 1.4;
+    }
+  }
+  &__info {
+    @include text-style(14, $gray-70, 400);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    line-height: 1.4;
+    @include mobile {
+      justify-content: space-between;
+      gap: 0;
+      font-size: 12px;
+      line-height: 1.2;
+    }
+  }
+}

--- a/src/components/Board/AnnouncementTitle/index.tsx
+++ b/src/components/Board/AnnouncementTitle/index.tsx
@@ -1,0 +1,23 @@
+import formatDate from "@/utils/formatDate";
+import { CommunityItemProps } from "../ListItem";
+import styles from "./index.module.scss";
+
+const AnnouncementTitle = ({ post }: { post: CommunityItemProps }) => {
+  const { id, userId, title, date, viewCount } = post;
+
+  return (
+    <section className={styles.title}>
+      <h3 className={styles.title__text}>{title}</h3>
+      <ul className={styles.title__info}>
+        <li>
+          <p>{formatDate(date, "MDMH")}</p>
+        </li>
+        <li>
+          <p>{`조회 ${viewCount.toLocaleString()}`}</p>
+        </li>
+      </ul>
+    </section>
+  );
+};
+
+export default AnnouncementTitle;

--- a/src/components/Board/Category/index.module.scss
+++ b/src/components/Board/Category/index.module.scss
@@ -1,0 +1,50 @@
+.tag {
+  &--page-list {
+    @include text-style(14, false, 600);
+    margin-bottom: 16px;
+    line-height: 1.4;
+    @include mobile {
+      margin-bottom: 8px;
+      font-size: 12px;
+      line-height: 1.2;
+    }
+  }
+  &--page-post {
+    @include text-style(16, false, 600);
+    @include mobile {
+      font-size: 12px;
+      line-height: 1.2;
+    }
+  }
+  &--board-community {
+    &--category-question {
+      color: $category-yellow;
+    }
+    &--category-know-how {
+      color: $category-purple;
+    }
+    &--category-accompany {
+      color: $category-mint;
+    }
+    &--category-others {
+      color: $category-pink;
+    }
+  }
+  &--board-follows {
+    &--category-blog {
+      color: $category-green;
+    }
+    &--category-instagram {
+      color: $category-purple;
+    }
+    &--category-youtube {
+      color: $category-pink;
+    }
+    &--category-tictoc {
+      color: $category-mint;
+    }
+    &--category-others {
+      color: $category-yellow;
+    }
+  }
+}

--- a/src/components/Board/Category/index.tsx
+++ b/src/components/Board/Category/index.tsx
@@ -1,0 +1,32 @@
+import { BoardType, CategoryType } from "@/@types/board";
+import ms from "@/utils/modifierSelector";
+import styles from "./index.module.scss";
+
+interface CategoryProps {
+  children: React.ReactNode;
+  pageType: "list" | "post";
+  boardType: BoardType;
+  categoryType: CategoryType;
+}
+
+const tag = ms(styles, "tag");
+
+const Category = ({
+  children,
+  pageType,
+  boardType,
+  categoryType,
+}: CategoryProps) => {
+  return (
+    <p
+      className={tag(
+        `--page-${pageType}`,
+        `--board-${boardType}--category-${categoryType}`,
+      )}
+    >
+      {children}
+    </p>
+  );
+};
+
+export default Category;

--- a/src/components/Board/EditDropdown/index.module.scss
+++ b/src/components/Board/EditDropdown/index.module.scss
@@ -1,0 +1,36 @@
+.wrapper {
+  position: relative;
+}
+
+.dropdown {
+  @include text-style(14, false, 400);
+  position: absolute;
+  right: 0;
+  width: max-content;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: center;
+  padding: 8px;
+  border-radius: 8px;
+  line-height: 1.4;
+  background-color: $white;
+  box-shadow: $board-box-shadow;
+  &__button {
+    @include flex();
+    gap: 4px;
+    padding: 8px;
+    border-radius: 4px;
+    &:hover {
+      background-color: $gray-10;
+    }
+    & > svg {
+      width: 20px;
+      height: 20px;
+    }
+  }
+}
+
+.delete-text {
+  color: $red;
+}

--- a/src/components/Board/EditDropdown/index.module.scss
+++ b/src/components/Board/EditDropdown/index.module.scss
@@ -1,5 +1,8 @@
 .wrapper {
   position: relative;
+  @include mobile {
+    display: none;
+  }
 }
 
 .dropdown {

--- a/src/components/Board/EditDropdown/index.tsx
+++ b/src/components/Board/EditDropdown/index.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { BoardType } from "@/@types/board";
+import IconKebab from "@/assets/icons/icon-kebab.svg";
+import IconEdit from "@/assets/icons/icon-edit.svg";
+import IconDelete from "@/assets/icons/icon-delete.svg";
+import styles from "./index.module.scss";
+
+interface EditDropdownProps {
+  boardType: BoardType;
+  id: number;
+}
+
+const EditDropdown = ({ boardType, id }: EditDropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <nav className={styles.wrapper}>
+      <button
+        type="button"
+        onClick={() => {
+          setIsOpen((prev) => !prev);
+        }}
+        aria-label="수정 삭제 버튼"
+      >
+        <IconKebab viewBox="0 0 24 24" />
+      </button>
+      {isOpen && (
+        <ul className={styles.dropdown}>
+          <li>
+            <Link
+              href={`/${boardType}/${id}/edit`}
+              className={styles.dropdown__button}
+            >
+              <p>수정하기</p>
+              <IconEdit viewBox="0 0 24 24" />
+            </Link>
+          </li>
+          <li>
+            <button type="button" className={styles.dropdown__button}>
+              <p className={styles["delete-text"]}>삭제하기</p>
+              <IconDelete viewBox="0 0 24 24" />
+            </button>
+          </li>
+        </ul>
+      )}
+    </nav>
+  );
+};
+
+export default EditDropdown;

--- a/src/components/Board/List/index.tsx
+++ b/src/components/Board/List/index.tsx
@@ -1,0 +1,25 @@
+import { BoardType } from "@/@types/board";
+import AnnouncementItem from "../AnnouncementItem";
+import ListItem, { CommunityItemProps } from "../ListItem";
+
+interface ListProps {
+  items: CommunityItemProps[];
+  boardType: BoardType;
+}
+
+const List = ({ items, boardType }: ListProps) => {
+  return (
+    <ul>
+      {items.map((boardItem) =>
+        boardType === "announcement" ? (
+          // eslint-disable-next-line
+          <AnnouncementItem key={boardItem.id} {...boardItem} />
+        ) : (
+          // eslint-disable-next-line
+          <ListItem key={boardItem.id} {...boardItem} />
+        ),
+      )}
+    </ul>
+  );
+};
+export default List;

--- a/src/components/Board/ListItem/index.module.scss
+++ b/src/components/Board/ListItem/index.module.scss
@@ -4,47 +4,6 @@
   @include mobile {
     margin: 16px 0;
   }
-  &__category {
-    @include text-style(14, false, 600);
-    margin-bottom: 16px;
-    line-height: 1.4;
-    @include mobile {
-      margin-bottom: 8px;
-      font-size: 12px;
-      line-height: 1.2;
-    }
-    &--board-community {
-      &--category-question {
-        color: $category-yellow;
-      }
-      &--category-know-how {
-        color: $category-purple;
-      }
-      &--category-accompany {
-        color: $category-mint;
-      }
-      &--category-others {
-        color: $category-pink;
-      }
-    }
-    &--board-follows {
-      &--category-blog {
-        color: $category-green;
-      }
-      &--category-instagram {
-        color: $category-purple;
-      }
-      &--category-youtube {
-        color: $category-pink;
-      }
-      &--category-tictoc {
-        color: $category-mint;
-      }
-      &--category-others {
-        color: $category-yellow;
-      }
-    }
-  }
   &__link {
     &:hover > h3 {
       text-decoration: underline;

--- a/src/components/Board/ListItem/index.tsx
+++ b/src/components/Board/ListItem/index.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
 import formatDate from "@/utils/formatDate";
-import ms from "@/utils/modifierSelector";
 import IconProfile from "@/assets/icons/icon-profile.svg";
 import IconComment from "@/assets/icons/icon-comment.svg";
 import { BoardType, CategoryId, CATEGORY_LIST } from "@/@types/board";
+import Category from "../Category";
 import styles from "./index.module.scss";
 
 export interface CommunityItemProps {
@@ -18,8 +18,6 @@ export interface CommunityItemProps {
   viewCount: number;
   commentCount: number;
 }
-
-const ac = ms(styles, "li__category");
 
 const ListItem = ({
   boardType,
@@ -41,9 +39,13 @@ const ListItem = ({
 
   return (
     <li className={styles.li}>
-      <p className={ac(`--board-${boardType}--category-${categoryType}`)}>
+      <Category
+        pageType="list"
+        boardType={boardType}
+        categoryType={categoryType}
+      >
         {categoryName}
-      </p>
+      </Category>
       <Link href={`/${boardType}/${id}`} className={styles.li__link}>
         <h3 className={styles.li__title}>{title}</h3>
         <p className={styles.li__preview}>{preview}</p>

--- a/src/components/Board/PostTitle/index.module.scss
+++ b/src/components/Board/PostTitle/index.module.scss
@@ -1,0 +1,71 @@
+.title {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  @include mobile {
+    gap: 8px;
+  }
+  &__top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  &__text {
+    @include text-style(20, false, 600);
+    @include mobile {
+      line-height: 1.4;
+    }
+  }
+  &__info {
+    @include text-style(14, $gray-70, 400);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    line-height: 1.4;
+    @include mobile {
+      justify-content: space-between;
+      gap: 0;
+      font-size: 12px;
+      line-height: 1.2;
+    }
+  }
+}
+
+.info-group {
+  @include flex;
+  gap: 16px;
+  @include mobile {
+    gap: 12px;
+  }
+}
+
+.profile {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  @include mobile {
+    gap: 4px;
+  }
+  & > svg {
+    width: 24px;
+    height: 24px;
+    @include mobile {
+      width: 20px;
+      height: 20px;
+    }
+  }
+}
+
+.comment {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  & > svg {
+    width: 16px;
+    height: 16px;
+    @include mobile {
+      width: 14px;
+      height: 14px;
+    }
+  }
+}

--- a/src/components/Board/PostTitle/index.tsx
+++ b/src/components/Board/PostTitle/index.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import { CATEGORY_LIST } from "@/@types/board";
+import formatDate from "@/utils/formatDate";
+import IconProfile from "@/assets/icons/icon-profile.svg";
+import IconComment from "@/assets/icons/icon-comment.svg";
+import Category from "../Category";
+import EditDropdown from "../EditDropdown";
+import { CommunityItemProps } from "../ListItem";
+import styles from "./index.module.scss";
+
+const PostTitle = ({ post }: { post: CommunityItemProps }) => {
+  const {
+    boardType,
+    id,
+    userId,
+    userNickname,
+    categoryId,
+    title,
+    date,
+    viewCount,
+    commentCount,
+  } = post;
+  const category = CATEGORY_LIST[boardType].find(
+    (item) => item.categoryId === categoryId,
+  );
+
+  if (!category) {
+    return null;
+  }
+
+  return (
+    <section className={styles.title}>
+      <aside className={styles.title__top}>
+        <Category
+          pageType="post"
+          boardType={boardType}
+          categoryType={category.categoryType}
+        >
+          {category.categoryName}
+        </Category>
+        <EditDropdown boardType={boardType} id={id} />
+      </aside>
+      <h3 className={styles.title__text}>{title}</h3>
+      <ul className={styles.title__info}>
+        <li className={styles["info-group"]}>
+          <Link href={`/profile/${userId}`} className={styles.profile}>
+            <IconProfile viewBox="0 0 36 36" />
+            <p>{userNickname}</p>
+          </Link>
+          <p>{formatDate(date, "MDMH")}</p>
+        </li>
+        <li className={styles["info-group"]}>
+          <p>{`조회 ${viewCount.toLocaleString()}`}</p>
+          <div className={styles.comment}>
+            <IconComment viewBox="0 0 24 24" />
+            <p>{commentCount.toLocaleString()}</p>
+          </div>
+        </li>
+      </ul>
+    </section>
+  );
+};
+
+export default PostTitle;

--- a/src/styles/constants/_colors.scss
+++ b/src/styles/constants/_colors.scss
@@ -51,3 +51,9 @@ $gradation-dain: linear-gradient(to bottom right, #4b65f7, #4bd0ff);
 $gradation-premium: linear-gradient(to bottom right, #6423ff, #c479ff);
 
 $box-shadow: 0 4px 12px 0 rgba(109, 106, 144, 0.2);
+
+$board-box-shadow:
+  0 25px 10px 0 rgba(109, 106, 144, 0.02),
+  0 14px 8px 0 rgba(109, 106, 144, 0.05),
+  0 6px 6px 0 rgba(109, 106, 144, 0.1),
+  2px 0 4px 0 rgba(109, 106, 144, 0.2);

--- a/src/styles/constants/_colors.scss
+++ b/src/styles/constants/_colors.scss
@@ -30,6 +30,8 @@ $purple-30: #8471f4;
 $purple-40: #7867de;
 $purple-50: #372f66;
 
+$red: #ff5959;
+
 $alert-red: #ff3d3d;
 $alert-green: #1ca22c;
 $alert-blue: #0167ff;


### PR DESCRIPTION
## 상세 페이지 제목

<img width="1680" alt="Screenshot 2024-08-26 at 9 24 34 PM" src="https://github.com/user-attachments/assets/632d12bc-171d-4a38-b39d-3c207aa1874c">

상세 페이지 제목 부분을 완성했습니다.
- 상세 페이지 라우팅
- 카테고리 태그, 수정/삭제 드롭다운 메뉴 분리

## 색상 변수 추가

```css
$red: #ff5959;

$board-box-shadow:
  0 25px 10px 0 rgba(109, 106, 144, 0.02),
  0 14px 8px 0 rgba(109, 106, 144, 0.05),
  0 6px 6px 0 rgba(109, 106, 144, 0.1),
  2px 0 4px 0 rgba(109, 106, 144, 0.2);
```
게시판 피그마에 있는 색상을 새로 추가했습니다.