### PR TITLE
체험단 관리 페이지 모바일 레이아웃

### DIFF
--- a/src/app/campaigns/[id]/manage/layout.module.scss
+++ b/src/app/campaigns/[id]/manage/layout.module.scss
@@ -1,9 +1,15 @@
 .layout {
   padding-top: 60px;
   padding-bottom: 176px;
+  @include tablet {
+    padding-top: 40px;
+  }
 }
 
 .title {
   @include text-style(32, false, 600);
   margin-bottom: 55px;
+  @include tablet {
+    display: none;
+  }
 }

--- a/src/app/campaigns/[id]/manage/page.module.scss
+++ b/src/app/campaigns/[id]/manage/page.module.scss
@@ -1,7 +1,14 @@
-.nav {
+.info {
   display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 20px;
-  margin-bottom: 26px;
+  flex-direction: column;
+  @include tablet {
+    flex-direction: column-reverse;
+  }
+}
+
+.divider {
+  display: none;
+  @include tablet {
+    display: block;
+  }
 }

--- a/src/app/campaigns/[id]/manage/page.tsx
+++ b/src/app/campaigns/[id]/manage/page.tsx
@@ -1,16 +1,19 @@
 import ManageProgress from "@/components/Campaigns/ManageProgress";
 import ManageTable from "@/components/Campaigns/ManageTable";
-import Button from "@/components/Button";
+import ManageButtons from "@/components/Campaigns/ManageButtons";
+import Line from "@/components/Line";
 import styles from "./page.module.scss";
 
 const Page = () => {
   return (
     <>
-      <nav className={styles.nav}>
-        <Button color="outline">일정확인</Button>
-        <Button color="solid">모집종료</Button>
-      </nav>
-      <ManageProgress activeIndex={0} />
+      <section className={styles.info}>
+        <ManageButtons />
+        <ManageProgress activeIndex={0} />
+      </section>
+      <section className={styles.divider}>
+        <Line type="thick" />
+      </section>
       <ManageTable />
     </>
   );

--- a/src/components/Campaigns/ManageButtons/index.module.scss
+++ b/src/components/Campaigns/ManageButtons/index.module.scss
@@ -1,0 +1,10 @@
+.nav {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 26px;
+  @include tablet {
+    margin-bottom: 28px;
+  }
+}

--- a/src/components/Campaigns/ManageButtons/index.tsx
+++ b/src/components/Campaigns/ManageButtons/index.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Button from "@/components/Button";
+import styles from "./index.module.scss";
+
+const ManageButtons = () => {
+  const [isMobile, setIsMobile] = useState<boolean>(false);
+
+  const handleResize = () => {
+    if (window.innerWidth <= 1024) {
+      setIsMobile(true);
+    }
+  };
+
+  useEffect(() => {
+    handleResize();
+  });
+
+  useEffect(() => {
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return (
+    <nav className={styles.nav}>
+      <Button color="outline" full={isMobile}>
+        일정확인
+      </Button>
+      <Button color="solid" full={isMobile}>
+        모집종료
+      </Button>
+    </nav>
+  );
+};
+
+export default ManageButtons;

--- a/src/components/Campaigns/ManageProgress/index.module.scss
+++ b/src/components/Campaigns/ManageProgress/index.module.scss
@@ -7,20 +7,36 @@
   flex-direction: column;
   gap: 18px;
   line-height: 1.4;
+  @include tablet {
+    @include text-style(14, $gray-50, 500);
+    gap: 9px;
+    margin-bottom: 22px;
+  }
 }
 
 .bar {
   @include flex();
   gap: 10px;
+  @include tablet {
+    gap: 6px;
+  }
   &__icon {
     @include flex();
     width: 100px;
     height: 100px;
     border: 2px solid $gray-30;
     border-radius: 50%;
+    @include tablet {
+      width: 60px;
+      height: 60px;
+    }
     & > svg {
       width: 60px;
       height: 60px;
+      @include tablet {
+        width: 32px;
+        height: 32px;
+      }
       & > path {
         stroke: $gray-40;
       }
@@ -43,6 +59,10 @@
     & > svg {
       width: 60px;
       height: 60px;
+      @include tablet {
+        width: 32px;
+        height: 32px;
+      }
       & > path {
         stroke: $gray-30;
       }
@@ -58,9 +78,15 @@
 .caption {
   @include flex();
   gap: 80px;
+  @include tablet {
+    gap: 44px;
+  }
   &__text {
     width: 100px;
     text-align: center;
+    @include tablet {
+      width: 60px;
+    }
     &--active,
     &--finished {
       color: $black;

--- a/src/components/Campaigns/ManageTable/index.module.scss
+++ b/src/components/Campaigns/ManageTable/index.module.scss
@@ -1,18 +1,36 @@
 .top {
   display: flex;
-  width: 1325px;
+  max-width: 1325px;
   margin: 0 auto;
   margin-bottom: 16px;
   justify-content: space-between;
   align-items: center;
+  @include tablet {
+    width: 100%;
+    margin-top: 22px;
+    margin-bottom: 20px;
+  }
   &__control {
     @include flex();
     @include text-style(15, false, 600);
     gap: 14px;
     line-height: 1.4;
+    @include tablet {
+      @include text-style(14, false, 400);
+    }
   }
   &__selected {
     @include text-style(16, false, 500);
+    line-height: 1.4;
+    @include tablet {
+      @include text-style(14, false, 400);
+    }
+  }
+}
+
+.selection-button-text {
+  @include tablet {
+    font-size: 14px;
     line-height: 1.4;
   }
 }

--- a/src/components/Campaigns/ManageTable/index.tsx
+++ b/src/components/Campaigns/ManageTable/index.tsx
@@ -178,11 +178,11 @@ const ManageTable = () => {
             // eslint-disable-next-line no-extra-boolean-cast
             selection: !!item.selection ? (
               <Button color="outline" padding="20px" disabled>
-                취소하기
+                <p className={styles["selection-button-text"]}>취소하기</p>
               </Button>
             ) : (
               <Button color="outline" padding="20px">
-                선정하기
+                <p className={styles["selection-button-text"]}>선정하기</p>
               </Button>
             ),
             platform: (

--- a/src/components/Mypage/Influencer/ProfileBox/index.tsx
+++ b/src/components/Mypage/Influencer/ProfileBox/index.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import ProfileImgUpload from "@/components/ProfileImgUpload";
-import SNSList from "@/components/SNSList";
+import SNSList, { SNSResponse } from "@/components/SNSList";
 import Button from "@/components/Button";
 import IconDirection from "@/assets/icons/icon-direction-right.svg";
 import styles from "./index.module.scss";
@@ -15,7 +15,7 @@ const ProfileBoxInfluencer = () => {
 
   const [isTablet, setIsTablet] = useState(false);
 
-  const snsResponseList = [
+  const snsResponseList: SNSResponse[] = [
     {
       snsType: "INSTAGRAM",
     },

--- a/src/components/SNSList/index.tsx
+++ b/src/components/SNSList/index.tsx
@@ -4,7 +4,7 @@ import styles from "./index.module.scss";
 
 type SNSType = "NAVER_BLOG" | "INSTAGRAM" | "YOUTUBE" | "TIKTOK" | "ETC";
 
-interface SNSResponse {
+export interface SNSResponse {
   snsType: SNSType;
 }
 

--- a/src/components/Table/index.module.scss
+++ b/src/components/Table/index.module.scss
@@ -1,18 +1,25 @@
 .table {
   @include text-style(16, false, 600);
-  width: fit-content;
   margin: 0 auto;
   line-height: 1.4;
+  overflow-x: scroll;
+  overflow-y: hidden;
 }
 
 .line {
   @include flex();
-  width: fit-content;
-  padding: 19px 0;
+  min-width: fit-content;
+  padding: 15px 0;
   border-bottom: 1px solid $gray-10;
+  @include mobile {
+    @include text-style(14, false, 400);
+    padding: 14px 0;
+  }
   &--head {
-    padding: 15px 0;
     background-color: $gray-20;
+    @include mobile {
+      @include text-style(14, false, 600);
+    }
   }
   &--active {
     background-color: $blue-10;
@@ -22,7 +29,13 @@
 .item {
   @include flex();
   width: 175px;
+  @include mobile {
+    width: 95px;
+  }
   &--index {
     width: 100px;
+    @include mobile {
+      width: 45px;
+    }
   }
 }

--- a/src/components/ToggleSwitch/index.module.scss
+++ b/src/components/ToggleSwitch/index.module.scss
@@ -1,3 +1,7 @@
+.wrapper {
+  @include flex();
+}
+
 .toggle {
   position: relative;
   appearance: none;
@@ -7,6 +11,10 @@
   border-radius: 30px;
   transition: background-color 0.3s ease-in;
   cursor: pointer;
+  @include tablet {
+    width: 40px;
+    height: 16px;
+  }
   &::after {
     content: "";
     position: absolute;
@@ -17,11 +25,14 @@
     transform: translateY(-50%);
     border-radius: 50%;
     background-color: $white;
-
     transition: left 0.2s linear;
     filter: drop-shadow(2px 0px 4px rgba(109, 106, 144, 0.2))
       drop-shadow(0px 4px 4px rgba(109, 106, 144, 0.05))
       drop-shadow(0px 25px 10px rgba(109, 106, 144, 0.02));
+    @include tablet {
+      width: 20px;
+      height: 20px;
+    }
   }
   &:checked {
     background-color: $blue-40;

--- a/src/components/ToggleSwitch/index.tsx
+++ b/src/components/ToggleSwitch/index.tsx
@@ -12,7 +12,7 @@ const toggle = ms(styles, "toggle");
 
 const ToggleSwitch = ({ id, register, ...props }: ToggleSwitchProps) => {
   return (
-    <label htmlFor={register ? register.name : ""}>
+    <label htmlFor={register ? register.name : ""} className={styles.wrapper}>
       {createElement("input", {
         type: "checkbox",
         className: toggle(),


### PR DESCRIPTION
## 체험단 관리 모바일 페이지

<img width="516" alt="Screenshot 2024-09-01 at 4 39 57 PM" src="https://github.com/user-attachments/assets/944c1bbd-dbb9-4dbd-8c90-1d949c9eaa8c">

체험단 관리 페이지 모바일 레이아웃을 추가하였습니다.

## SNSReponse 타입 에러

```typescript
const snsResponseList: SNSResponse[] = [
...
```

MyPage/Influencer/ProfileBox에서 있던 에러를 타입 정의해서 수정했습니다.